### PR TITLE
[initrd] Set amount of reserved disk space to 0. Contributes to JB32700

### DIFF
--- a/etc/sysconfig/init
+++ b/etc/sysconfig/init
@@ -1,0 +1,8 @@
+# Common settings for normal and recovery init.
+
+# Amount of space to keep unallocated for refilling root or home later on.
+# Please keep this multiple of 500MB.
+LVM_RESERVED_MB=0
+
+# Default size for root LV
+LVM_ROOT_SIZE=4000

--- a/mksfosinitrd.sh
+++ b/mksfosinitrd.sh
@@ -6,6 +6,7 @@
 # Add your tools here. They need to be present in your sb2 target.
 # These tools will be included both to normal and recovery initrd.
 TOOL_LIST="					\
+	etc/sysconfig/*				\
 	res/images/*				\
 	sbin/*					\
 	/sbin/e2fsck				\
@@ -84,6 +85,8 @@ cd "$TMP_DIR"
 # Copy local files to be added to initrd. If you add more, add also to TOOL_LIST.
 cp -a "$OLD_DIR"/sbin .
 cp -a "$OLD_DIR"/res .
+mkdir -p etc
+cp -a "$OLD_DIR"/etc/sysconfig etc
 
 # Copy recovery files
 if test x"$1" = x"recovery"; then

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -27,6 +27,8 @@ if [ -z $1 ] || [ ! -e $1 ]; then
 	exit 1
 fi
 
+. /etc/sysconfig/init
+
 PHYSDEV_SEARCHLIST="sailfish sailfishos userdata"
 
 for label in $PHYSDEV_SEARCHLIST; do
@@ -46,12 +48,7 @@ ROOTDEV="/dev/sailfish/root"
 HOMEDEV="/dev/sailfish/home"
 MOUNT_POINT=$1
 
-# Amount of space to keep unallocated for refilling root or home later on.
-# Please keep this multiple of 500MB
-RESERVE_MB=3000
-RESERVE_KB=$(expr $RESERVE_MB \* 1024)
-# Default size for root LV
-ROOT_SIZE=4000
+LVM_RESERVED_KB=$(expr $LVM_RESERVED_MB \* 1024)
 
 pwr_key_wait()
 {
@@ -85,13 +82,13 @@ check_firstboot_resize()
 	EXTENT_SIZE=$(lvm vgdisplay sailfish -c | cut -d ":" -f 13)
 	FREE_KB=$(expr $FREE_EXTENTS \* $EXTENT_SIZE)
 
-	if test "$FREE_KB" -le "$RESERVE_KB"; then
+	if test "$FREE_KB" -le "$LVM_RESERVED_KB"; then
 		# The space is allocated, nothing to do.
 		return 0
 	fi
 
 	# Increase root size
-	if lvm lvextend --size "$ROOT_SIZE"M "$ROOTDEV"; then
+	if lvm lvextend --size "$LVM_ROOT_SIZE"M "$ROOTDEV"; then
 		e2fsck -f -y "$ROOTDEV" > /dev/kmsg
 		resize2fs -f "$ROOTDEV" > /dev/kmsg
 	else
@@ -101,7 +98,7 @@ check_firstboot_resize()
 	# Check how much space we can add to home
 	FREE_EXTENTS=$(lvm vgdisplay sailfish -c | cut -d ":" -f 16)
 	HOME_KB=$(expr $FREE_EXTENTS \* $EXTENT_SIZE)
-	HOME_KB=$(expr $HOME_KB - $RESERVE_KB)
+	HOME_KB=$(expr $HOME_KB - $LVM_RESERVED_KB)
 
 	# Increase home size by HOME_KB
 	if lvm lvextend --size +"$HOME_KB"K $HOMEDEV; then
@@ -128,7 +125,7 @@ factory_reset_if_needed()
 
 		YAMUIPID=$!
 
-		if factory-reset-lvm $ROOT_SIZE $RESERVE_MB; then
+		if factory-reset-lvm $LVM_ROOT_SIZE $LVM_RESERVED_MB; then
 			# Successful recovery.
 
 			kill "$YAMUIPID"

--- a/usr/bin/recovery-menu
+++ b/usr/bin/recovery-menu
@@ -26,6 +26,7 @@
 # Exit immediately if a command fails
 set -e
 
+. /etc/sysconfig/init
 . /usr/bin/recovery-functions.sh
 
 DEVICELOCK_SCRIPT_ABS_PATH=/usr/bin/recovery-menu-devicelock
@@ -147,7 +148,7 @@ setup_reset()
 	lock_exclusive
 	call_devlock_action
 
-	if ! factory-reset-lvm 4000 3000; then
+	if ! factory-reset-lvm $LVM_ROOT_SIZE $LVM_RESERVED_MB; then
 		echo_err "[ERROR] Factory reset failed."
 		unlock
 		return 1


### PR DESCRIPTION
We don't need to reserve 3 GB for partition resize now.

Refactor disk space settings to /etc/sysconfig/init since they
are used both by regular and recovery init.

Rename RESERVE_MB to LVM_RESERVED_MB, RESERVE_KB to LVM_RESERVED_KB,
ROOT_SIZE to LVM_ROOT_SIZE to be more clear.

Signed-off-by: Igor Zhbanov <igor.zhbanov@jolla.com>