### PR TITLE
Add configurable partition label file

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -11,6 +11,8 @@
 #                %{devicetree}" to build with the standard binaries from
 #                droid-hal-device kernel package.
 #
+# root_part_label:	Sailfish OS partition label, single string
+# factory_part_label:	Factory image partition label, single string
 #
 # Adding device specific files to initrd folder:
 #
@@ -117,6 +119,18 @@ cp -af initrd/* %{_local_initrd_dir}
 if test -d initrd-%{device}; then
 	cp -af initrd-%{device}/* %{_local_initrd_dir}/
 fi
+
+# modify partition labels
+%if 0%{!?root_part_label:1}
+%define root_part_label sailfish
+%endif
+
+%if 0%{!?factory_part_label:1}
+%define factory_part_label fimage
+%endif
+
+sed --in-place 's|@PHYSDEV_PART_LABEL@|%{root_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
+sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 
 # Create a hybris-boot.img image from the zImage
 pushd %{_local_initrd_dir}

--- a/etc/sysconfig/partitions
+++ b/etc/sysconfig/partitions
@@ -1,0 +1,7 @@
+# Common partition labels used by initrd
+
+# Default sailfish OS partition label
+PHYSDEV_PART_LABEL=@PHYSDEV_PART_LABEL@
+
+# Default factory partition label
+FIMAGE_PART_LABEL=@FIMAGE_PART_LABEL@

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -28,8 +28,9 @@ if [ -z $1 ] || [ ! -e $1 ]; then
 fi
 
 . /etc/sysconfig/init
+. /etc/sysconfig/partitions
 
-PHYSDEV_SEARCHLIST="sailfish sailfishos userdata"
+PHYSDEV_SEARCHLIST="$PHYSDEV_PART_LABEL sailfishos"
 
 for label in $PHYSDEV_SEARCHLIST; do
 	PHYSDEV=$(find-mmc-bypartlabel "$label")


### PR DESCRIPTION
Configurable partition label file allow adjusting easily
used sailfish OS and factory image partition labels.