### PR TITLE
[recovery]. Replase evkey by yamui-powerkey. Contributes to JB#32244

### DIFF
--- a/mksfosinitrd.sh
+++ b/mksfosinitrd.sh
@@ -15,6 +15,7 @@ TOOL_LIST="					\
 	/sbin/mkfs.ext4				\
 	/sbin/resize2fs				\
 	/usr/bin/yamui				\
+	/usr/bin/yamui-powerkey			\
 	/usr/bin/yamui-screensaverd"
 
 # These tools will be included to recovery initrd only.

--- a/recovery-init
+++ b/recovery-init
@@ -63,13 +63,6 @@ ipaddr add 10.42.66.66/29 broadcast 10.42.66.255 dev rndis0
 ipaddr add 192.168.2.15/24 broadcast 192.168.2.255 dev rndis0 label rndis0:0
 udhcpd
 
-for dev in $(ls -1 -d /sys/class/input/event*); do
-	if cat $dev/device/name | grep dollar_cove_power_button; then
-		ln -s /dev/input/$(echo $dev | cut -d '/' -f 5) /dev/powerkey
-		break
-	fi
-done
-
 echo V > /dev/watchdog
 
 # On intel platform the framebuffer seems to stay on, so just draw and exit

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -55,27 +55,19 @@ ROOT_SIZE=4000
 
 pwr_key_wait()
 {
-	while true; do
-		key=$(/sbin/evkey -d -t 3000 /dev/input/event6)
+	# Waiting for Power key pressed for 3 seconds and released.
+	if /usr/bin/yamui-powerkey -u; then
+		# Turn on RED led
+		echo 255 > /sys/class/leds/led:rgb_red/brightness
+		# Kill UI process
+		kill $1
+		# Let user see the red LED for couple of seconds.
+		sleep 2
+		# clear any pending RTC wake up so we don't wake up
+		rtc-clear
 
-		if [ "x${key}" == "x116" ]; then
-			key=null
-			key=$(/sbin/evkey -u -t 2000 /dev/input/event6)
-
-			if ! [ "x${key}" == "x116" ]; then
-				# Turn on RED led
-				echo 255 > /sys/class/leds/led:rgb_red/brightness
-				# Kill UI process
-				kill $1
-				# Let user see the red LED for couple of seconds.
-				sleep 2
-				# clear any pending RTC wake up so we don't wake up
-				rtc-clear
-
-				poweroff -f
-			fi
-		fi
-	done
+		poweroff -f
+	fi
 }
 
 # This function should not fail even if the operations cannot be performed

--- a/usr/bin/powerkey-handler.sh
+++ b/usr/bin/powerkey-handler.sh
@@ -2,11 +2,8 @@
 
 . /usr/bin/recovery-functions.sh
 
-while true; do
-	key=$(/sbin/evkey -d -t 3000 /dev/powerkey)
-
-	if [ "x${key}" == "x116" ]; then
-		echo "Powerkey pressed, rebooting the device..."
-		reboot_device
-	fi
-done
+# Waiting for key pressed for 3 seconds.
+if /usr/bin/yamui-powerkey; then
+	echo "Powerkey pressed, rebooting the device..."
+	reboot_device
+fi


### PR DESCRIPTION
Make Power key handling device independent by using yamui-powerkey
instead of evkey.
Remove /dev/powerkey symlink creation.

Signed-off-by: Igor Zhbanov <igor.zhbanov@jolla.com>