### PR TITLE
[recovery] Replase evkey by yamui-powerkey. Contributes to JB#32244

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -11,6 +11,8 @@
 #                %{devicetree}" to build with the standard binaries from
 #                droid-hal-device kernel package.
 #
+# root_part_label:	Sailfish OS partition label, single string
+# factory_part_label:	Factory image partition label, single string
 #
 # Adding device specific files to initrd folder:
 #
@@ -117,6 +119,18 @@ cp -af initrd/* %{_local_initrd_dir}
 if test -d initrd-%{device}; then
 	cp -af initrd-%{device}/* %{_local_initrd_dir}/
 fi
+
+# modify partition labels
+%if 0%{!?root_part_label:1}
+%define root_part_label sailfish
+%endif
+
+%if 0%{!?factory_part_label:1}
+%define factory_part_label fimage
+%endif
+
+sed --in-place 's|@PHYSDEV_PART_LABEL@|%{root_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
+sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 
 # Create a hybris-boot.img image from the zImage
 pushd %{_local_initrd_dir}

--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -132,6 +132,18 @@ fi
 sed --in-place 's|@PHYSDEV_PART_LABEL@|%{root_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 
+# modify display settings
+%if 0%{!?display_brightness_path:1}
+%define display_brightness_path /sys/class/backlight/intel_backlight/brightness
+%endif
+
+%if 0%{!?display_brightness:1}
+%define display_brightness 0
+%endif
+
+sed --in-place 's|@DISPLAY_BRIGHTNESS_PATH@|%{display_brightness_path}|' %{_local_initrd_dir}/etc/sysconfig/display
+sed --in-place 's|@DISPLAY_BRIGHTNESS@|%{display_brightness}|' %{_local_initrd_dir}/etc/sysconfig/display
+
 # Create a hybris-boot.img image from the zImage
 pushd %{_local_initrd_dir}
 ./mksfosinitrd.sh

--- a/etc/sysconfig/display
+++ b/etc/sysconfig/display
@@ -1,0 +1,7 @@
+# Common display settings used by initrd
+
+# Display brightness sysfs path
+DISPLAY_BRIGHTNESS_PATH=@DISPLAY_BRIGHTNESS_PATH@
+
+# Display brightnes
+DISPLAY_BRIGHTNESS=@DISPLAY_BRIGHTNESS@

--- a/etc/sysconfig/partitions
+++ b/etc/sysconfig/partitions
@@ -1,0 +1,7 @@
+# Common partition labels used by initrd
+
+# Default sailfish OS partition label
+PHYSDEV_PART_LABEL=@PHYSDEV_PART_LABEL@
+
+# Default factory partition label
+FIMAGE_PART_LABEL=@FIMAGE_PART_LABEL@

--- a/mksfosinitrd.sh
+++ b/mksfosinitrd.sh
@@ -16,6 +16,7 @@ TOOL_LIST="					\
 	/sbin/mkfs.ext4				\
 	/sbin/resize2fs				\
 	/usr/bin/yamui				\
+	/usr/bin/yamui-powerkey			\
 	/usr/bin/yamui-screensaverd"
 
 # These tools will be included to recovery initrd only.

--- a/recovery-init
+++ b/recovery-init
@@ -25,6 +25,7 @@
 
 export PATH=/sbin:/bin:/usr/bin:/usr/sbin
 
+. /etc/sysconfig/display
 . /usr/bin/recovery-functions.sh
 
 echo "Doing mounts... "
@@ -45,7 +46,7 @@ write()
 }
 
 # Minimize power consumption by lowering display brightness to minimum
-write /sys/class/backlight/intel_backlight/brightness 0
+write $DISPLAY_BRIGHTNESS_PATH $DISPLAY_BRIGHTNESS
 
 write /sys/class/android_usb/android0/enable 0
 write /sys/class/android_usb/android0/idVendor 2931
@@ -65,8 +66,7 @@ udhcpd
 
 echo V > /dev/watchdog
 
-# On intel platform the framebuffer seems to stay on, so just draw and exit
-yamui -t "RECOVERY: Connect USB cable and open telnet connection to address 10.42.66.66" -s 1
+yamui -t "RECOVERY: Connect USB cable and open telnet to address 10.42.66.66" &
 
 # Remove recovery-menu lock if the /var/run is not on tmpfs.
 remove_lock

--- a/recovery-init
+++ b/recovery-init
@@ -63,13 +63,6 @@ ipaddr add 10.42.66.66/29 broadcast 10.42.66.255 dev rndis0
 ipaddr add 192.168.2.15/24 broadcast 192.168.2.255 dev rndis0 label rndis0:0
 udhcpd
 
-for dev in $(ls -1 -d /sys/class/input/event*); do
-	if cat $dev/device/name | grep dollar_cove_power_button; then
-		ln -s /dev/input/$(echo $dev | cut -d '/' -f 5) /dev/powerkey
-		break
-	fi
-done
-
 echo V > /dev/watchdog
 
 # On intel platform the framebuffer seems to stay on, so just draw and exit

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -28,8 +28,9 @@ if [ -z $1 ] || [ ! -e $1 ]; then
 fi
 
 . /etc/sysconfig/init
+. /etc/sysconfig/partitions
 
-PHYSDEV_SEARCHLIST="sailfish sailfishos userdata"
+PHYSDEV_SEARCHLIST="$PHYSDEV_PART_LABEL sailfishos"
 
 for label in $PHYSDEV_SEARCHLIST; do
 	PHYSDEV=$(find-mmc-bypartlabel "$label")

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -52,27 +52,19 @@ LVM_RESERVED_KB=$(expr $LVM_RESERVED_MB \* 1024)
 
 pwr_key_wait()
 {
-	while true; do
-		key=$(/sbin/evkey -d -t 3000 /dev/input/event6)
+	# Waiting for Power key pressed for 3 seconds and released.
+	if /usr/bin/yamui-powerkey -u; then
+		# Turn on RED led
+		echo 255 > /sys/class/leds/led:rgb_red/brightness
+		# Kill UI process
+		kill $1
+		# Let user see the red LED for couple of seconds.
+		sleep 2
+		# clear any pending RTC wake up so we don't wake up
+		rtc-clear
 
-		if [ "x${key}" == "x116" ]; then
-			key=null
-			key=$(/sbin/evkey -u -t 2000 /dev/input/event6)
-
-			if ! [ "x${key}" == "x116" ]; then
-				# Turn on RED led
-				echo 255 > /sys/class/leds/led:rgb_red/brightness
-				# Kill UI process
-				kill $1
-				# Let user see the red LED for couple of seconds.
-				sleep 2
-				# clear any pending RTC wake up so we don't wake up
-				rtc-clear
-
-				poweroff -f
-			fi
-		fi
-	done
+		poweroff -f
+	fi
 }
 
 # This function should not fail even if the operations cannot be performed

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -29,6 +29,7 @@ fi
 
 . /etc/sysconfig/init
 . /etc/sysconfig/partitions
+. /etc/sysconfig/display
 
 PHYSDEV_SEARCHLIST="$PHYSDEV_PART_LABEL sailfishos"
 
@@ -110,6 +111,17 @@ factory_reset_if_needed()
 			REBOOT=1
 		fi
 		umount $1
+
+		echo "Mount sysfs... "
+		mount /sys
+
+		write()
+		{
+			echo -n "$2" > $1
+		}
+
+		# Minimize power consumption by lowering display brightness to minimum
+		write $DISPLAY_BRIGHTNESS_PATH $DISPLAY_BRIGHTNESS
 
 		yamui -a 1100 -t "Resetting to factory state, please do not power off!" \
 		animation-recover-001 animation-recover-002 animation-recover-003 \

--- a/usr/bin/powerkey-handler.sh
+++ b/usr/bin/powerkey-handler.sh
@@ -2,11 +2,8 @@
 
 . /usr/bin/recovery-functions.sh
 
-while true; do
-	key=$(/sbin/evkey -d -t 3000 /dev/powerkey)
-
-	if [ "x${key}" == "x116" ]; then
-		echo "Powerkey pressed, rebooting the device..."
-		reboot_device
-	fi
-done
+# Waiting for key pressed for 3 seconds.
+if /usr/bin/yamui-powerkey; then
+	echo "Powerkey pressed, rebooting the device..."
+	reboot_device
+fi


### PR DESCRIPTION
Make Power key handling device independent by using yamui-powerkey
instead of evkey.
Remove /dev/powerkey symlink creation.

Signed-off-by: Igor Zhbanov <igor.zhbanov@jolla.com>