### PR TITLE
[recovery] Correct brightness level set in init script. Fixes JB#32824

### DIFF
--- a/recovery-init
+++ b/recovery-init
@@ -45,7 +45,7 @@ write()
 }
 
 # Minimize power consumption by lowering display brightness to minimum
-write /sys/class/backlight/intel_backlight/brightness 0
+write /sys/class/leds/lcd-backlight/brightness 16
 
 write /sys/class/android_usb/android0/enable 0
 write /sys/class/android_usb/android0/idVendor 2931
@@ -72,8 +72,7 @@ done
 
 echo V > /dev/watchdog
 
-# On intel platform the framebuffer seems to stay on, so just draw and exit
-yamui -t "RECOVERY: Connect USB cable and open telnet connection to address 10.42.66.66" -s 1
+yamui -t "RECOVERY: Connect USB cable and open telnet connection to address 10.42.66.66"
 
 # Remove recovery-menu lock if the /var/run is not on tmpfs.
 remove_lock


### PR DESCRIPTION
- Corrected brightness node and set 16 level by default
- Removed parameter -s from command of running yamui command