### PR TITLE
[recovery] Make battery threshold a configurable option. Fixes JB#32948

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -14,6 +14,9 @@
 # root_part_label:	Sailfish OS partition label, single string
 # factory_part_label:	Factory image partition label, single string
 #
+# battery_capacity_threshold: Battery threshold for factory reset [0, 100].
+#                             Default 0 (no threshold).
+#
 # Adding device specific files to initrd folder:
 #
 # Create a folder named initrd-%{device} and copy the overriding files there.
@@ -143,6 +146,12 @@ sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_di
 
 sed --in-place 's|@DISPLAY_BRIGHTNESS_PATH@|%{display_brightness_path}|' %{_local_initrd_dir}/etc/sysconfig/display
 sed --in-place 's|@DISPLAY_BRIGHTNESS@|%{display_brightness}|' %{_local_initrd_dir}/etc/sysconfig/display
+
+%if 0%{!?battery_capacity_threshold:1}
+%define battery_capacity_threshold 0
+%endif
+
+sed --in-place 's|@BATTERY_CAPACITY_THRESHOLD@|%{battery_capacity_threshold}|' %{_local_initrd_dir}/etc/sysconfig/recovery
 
 # Create a hybris-boot.img image from the zImage
 pushd %{_local_initrd_dir}

--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -14,6 +14,7 @@
 # root_part_label:	Sailfish OS partition label, single string
 # factory_part_label:	Factory image partition label, single string
 #
+# battery_capacity_file:      Path to read current battery charge from.
 # battery_capacity_threshold: Battery threshold for factory reset [0, 100].
 #                             Default 0 (no threshold).
 #
@@ -147,10 +148,15 @@ sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_di
 sed --in-place 's|@DISPLAY_BRIGHTNESS_PATH@|%{display_brightness_path}|' %{_local_initrd_dir}/etc/sysconfig/display
 sed --in-place 's|@DISPLAY_BRIGHTNESS@|%{display_brightness}|' %{_local_initrd_dir}/etc/sysconfig/display
 
+%if 0%{!?battery_capacity_file:1}
+%define battery_capacity_file "/sys/class/power_supply/*_battery/capacity"
+%endif
+
 %if 0%{!?battery_capacity_threshold:1}
 %define battery_capacity_threshold 0
 %endif
 
+sed --in-place 's|@BATTERY_CAPACITY_FILE@|%{battery_capacity_file}|' %{_local_initrd_dir}/etc/sysconfig/recovery
 sed --in-place 's|@BATTERY_CAPACITY_THRESHOLD@|%{battery_capacity_threshold}|' %{_local_initrd_dir}/etc/sysconfig/recovery
 
 # Create a hybris-boot.img image from the zImage

--- a/etc/sysconfig/recovery
+++ b/etc/sysconfig/recovery
@@ -1,2 +1,5 @@
+# Path to file to read current battery charge from.
+BATTERY_CAPACITY_FILE=@BATTERY_CAPACITY_FILE@
+
 # Battery charged capacity threshold before allowing to start a factory reset
 BATTERY_CAPACITY_THRESHOLD=@BATTERY_CAPACITY_THRESHOLD@

--- a/etc/sysconfig/recovery
+++ b/etc/sysconfig/recovery
@@ -1,0 +1,2 @@
+# Battery charged capacity threshold before allowing to start a factory reset
+BATTERY_CAPACITY_THRESHOLD=@BATTERY_CAPACITY_THRESHOLD@

--- a/usr/bin/recovery-menu
+++ b/usr/bin/recovery-menu
@@ -32,7 +32,6 @@ set -e
 
 DEVICELOCK_SCRIPT_ABS_PATH=/usr/bin/recovery-menu-devicelock
 ROOTFS=/rootfs
-BATTERY_CAPACITY_FILE="/sys/class/power_supply/*_battery/capacity"
 
 if [ -f /etc/moslo-version ]; then
 	VERSION=$(cat /etc/moslo-version)

--- a/usr/bin/recovery-menu
+++ b/usr/bin/recovery-menu
@@ -27,12 +27,12 @@
 set -e
 
 . /etc/sysconfig/init
+. /etc/sysconfig/recovery
 . /usr/bin/recovery-functions.sh
 
 DEVICELOCK_SCRIPT_ABS_PATH=/usr/bin/recovery-menu-devicelock
 ROOTFS=/rootfs
 BATTERY_CAPACITY_FILE="/sys/class/power_supply/*_battery/capacity"
-BATTERY_CAPACITY_THRESHOLD=5
 
 if [ -f /etc/moslo-version ]; then
 	VERSION=$(cat /etc/moslo-version)
@@ -128,6 +128,11 @@ run_action()
 
 assure_battery_is_charged_enough()
 {
+	# Always allow on zero threshold
+	if [ "x$BATTERY_CAPACITY_THRESHOLD" = "x0" ]; then
+		return 0
+	fi
+
 	local capacity=$(cat $BATTERY_CAPACITY_FILE 2>/dev/null)
 	if [ 0$capacity -lt $BATTERY_CAPACITY_THRESHOLD ]; then
 		echo "Battery level is low: $capacity%."


### PR DESCRIPTION
The battery capacity threshold for allowing factory reset can be omitted
on devices that can charge the device from PC USB cable (500mA). Make
it a configurable variable "battery_capacity_threshold" for device
specific spec files. If not defined, the default is set to 0 (always
allow).

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>