### PR TITLE
[devicelock] Check for file instead of symlink. Fixes JB#33625

### DIFF
--- a/usr/bin/recovery-menu-devicelock
+++ b/usr/bin/recovery-menu-devicelock
@@ -36,7 +36,7 @@ ask_and_check_code()
 	local PLUGIN="chroot $ROOTFS_PATH $PLUGIN_PATH"
 
 	# If we can't access, assume rootfs is broken and skip device lock check
-	if [ ! -h $ROOTFS_PATH$PLUGIN_PATH ]; then
+	if [ ! -x $ROOTFS_PATH$PLUGIN_PATH ]; then
 		echo "[WARNING] Root file system unaccessible, bypassing device lock check."
 		return 0
 	fi


### PR DESCRIPTION
If encpartition plugin is used instead of encsfa, the encpartition
binary is actual binary file instead of symlink. This check for
symlink falsely fails in that case. Changed the check to just normal
file check to fix the issue.

Signed-off-by: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>