### PR TITLE
Add an option to clear external storage to device reset

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -138,8 +138,13 @@ fi
 %define factory_part_label fimage
 %endif
 
+%if 0%{!?external_media_devices:1}
+%define external_media_devices /dev/mmcblk[1-9]*p[1-9]*
+%endif
+
 sed --in-place 's|@PHYSDEV_PART_LABEL@|%{root_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
+sed --in-place 's|@EXTERNAL_MEDIA_DEVICES@|%{external_media_devices}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 
 # modify display settings
 %if 0%{!?display_brightness_path:1}

--- a/etc/sysconfig/partitions
+++ b/etc/sysconfig/partitions
@@ -5,3 +5,6 @@ PHYSDEV_PART_LABEL=@PHYSDEV_PART_LABEL@
 
 # Default factory partition label
 FIMAGE_PART_LABEL=@FIMAGE_PART_LABEL@
+
+# Factory resetable external media device paths
+EXTERNAL_MEDIA_DEVICES="@EXTERNAL_MEDIA_DEVICES@"

--- a/mksfosinitrd.sh
+++ b/mksfosinitrd.sh
@@ -10,6 +10,7 @@ TOOL_LIST="					\
 	res/images/*				\
 	sbin/*					\
 	/sbin/e2fsck				\
+	/sbin/factory-reset-external		\
 	/sbin/factory-reset-lvm			\
 	/sbin/find-mmc-bypartlabel		\
 	/usr/sbin/lvm				\

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -113,6 +113,9 @@ factory_reset_if_needed()
 		if test -f $1/usr/share/lipstick/devicelock/.clear-device-full-wipe; then
 			export SAILFISHOS_WIPE_PARTITIONS="1"
 		fi
+		if test -f $1/usr/share/lipstick/devicelock/.clear-device-external-media; then
+			CLEAR_EXTERNAL_MEDIA=1
+		fi
 		umount $1
 
 		log "Mounting sysfs."
@@ -135,6 +138,10 @@ factory_reset_if_needed()
 
 		if factory-reset-lvm $LVM_ROOT_SIZE $LVM_RESERVED_MB; then
 			# Successful recovery.
+
+			if test "$CLEAR_EXTERNAL_MEDIA" = "1" && ! factory-reset-external $EXTERNAL_MEDIA_DEVICES; then
+				log "Requested clear of external storage but the command failed."
+			fi
 
 			kill "$YAMUIPID"
 			# TODO: maybe replace this with a big-ass OK-sign png..


### PR DESCRIPTION
…. Contributes to JB#38804

This will invoke a device adaptation specific factory-reset-external
script if an external storage clear is requested and the script exists.