### PR TITLE
Don't mount /home during init.

### DIFF
--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -191,9 +191,8 @@ fi
 # Check and resize root and home in case usage indicates first boot
 check_firstboot_resize
 
-# TODO: revisit for encryption, where home would not be mounted here.
-if (mount -t ext4 $ROOTDEV $1 && mount -t ext4 $HOMEDEV $1/home); then
-	log "Root and home partitions are mounted."
+if mount -t ext4 $ROOTDEV $1; then
+	log "Root partition is mounted."
 	# If we are here then filesystem is already resized.
 	touch "$1/$FS_RESIZED"
 	exit 0


### PR DESCRIPTION
This will happen later in the system startup process after the user
has been prompted to enter a passcode to unlock the home partition
if it is encrypted.  If it is not encrypted then mounting home will
just happen later in the system startup process.