### PR TITLE
[recovery] Include cryptsetup. Fixes JB#45760

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -76,6 +76,9 @@ BuildRequires:  openssh-server
 # mkbootimg needs python
 BuildRequires:  python
 
+# tools
+BuildRequires:  cryptsetup
+
 # Run time requires for flashing the bootimg
 Requires:       droid-config-flashing
 

--- a/mksfosinitrd.sh
+++ b/mksfosinitrd.sh
@@ -38,7 +38,8 @@ RECOVERY_FILES="				\
 	/lib/libnss_files.so.2			\
 	/usr/bin/scp				\
 	/usr/libexec/openssh/sftp-server	\
-	/usr/sbin/sshd"
+	/usr/sbin/sshd				\
+	/usr/sbin/cryptsetup"
 
 # The sshd config file and keys must be accessible by files owner only.
 # Git doesn't preserve full file permissions.


### PR DESCRIPTION
This allows opening encrypted volumes in recovery mode.