### PR TITLE
Bind mount /dev and /proc under rootfs. JB#45953

### DIFF
--- a/usr/bin/recovery-menu
+++ b/usr/bin/recovery-menu
@@ -87,6 +87,8 @@ lvm_mount()
 
 	mkdir -p $ROOTFS
 	mount /dev/sailfish/root $ROOTFS || true
+	mount -o bind /dev $ROOTFS/dev || true
+	mount -o bind /proc $ROOTFS/proc || true
 }
 
 lvm_umount()
@@ -96,6 +98,8 @@ lvm_umount()
 		return 0
 	fi
 
+	umount $ROOTFS/proc || true
+	umount $ROOTFS/dev || true
 	umount $ROOTFS || true
 	lvm vgchange -a n || true
 	# Do NOT replace rmdir with rm -rf, as end user might had left something there


### PR DESCRIPTION
New devicelock code requires /dev and /proc to be accessible. This makes
them available inside chroot that is used for devicelock check in
recovery mode.