### PR TITLE
Allow to read from /boot.

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -78,7 +78,14 @@ BuildRequires:  openssh-server
 BuildRequires:  python
 
 # tools
+Buildrequires:  coreutils
 BuildRequires:  cryptsetup
+BuildRequires:  sed
+
+%if 0%{?_obs_build_project:1}
+# /boot
+BuildRequires: sudo-for-abuild
+%endif
 
 # Run time requires for flashing the bootimg
 Requires:       droid-config-flashing
@@ -174,6 +181,9 @@ sed --in-place 's|@BATTERY_CAPACITY_FILE@|%{battery_capacity_file}|' %{_local_in
 sed --in-place 's|@BATTERY_CAPACITY_THRESHOLD@|%{battery_capacity_threshold}|' %{_local_initrd_dir}/etc/sysconfig/recovery
 
 # Create a hybris-boot.img image from the zImage
+%if 0%{?_obs_build_project:1}
+sudo chmod 755 /boot
+%endif
 pushd %{_local_initrd_dir}
 ./mksfosinitrd.sh
 popd


### PR DESCRIPTION
This is needed in OBS because of:
https://git.sailfishos.org/mer-core/filesystem/commit/e1ab8c94327a19f4bb39e4ff81732192ee28941c