### PR TITLE
[initrd] Fix the OBS building error for a case without tag placed on the git. Contributes to JB#52476

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -54,7 +54,11 @@
 
 Name:       droid-hal-%{device}-img-boot
 Summary:    Kernel boot image for %{device}
+%if 0%{?_obs_build_project:1}
+Version:    0.0.1
+%else
 Version:    %{localver}
+%endif
 Release:    1
 Group:      Kernel/Linux Kernel
 License:    GPLv2


### PR DESCRIPTION
The OBS build without the git tag will have the error.
Because the OBS replace the Version field in the spec.