### PR TITLE
[initrd] Pass device-specific environment variables to initrd. JB#54875 

### DIFF
--- a/droid-hal-device-img-boot.inc
+++ b/droid-hal-device-img-boot.inc
@@ -18,6 +18,13 @@
 # battery_capacity_threshold: Battery threshold for factory reset [0, 100].
 #                             Default 0 (no threshold).
 #
+# initrd_env_vars:            Pass the list of variables to /etc/sysconfig/init
+#                             Define as follows (deduplicate percentage sign):
+#                             %%define initrd_env_vars \
+#                             FOO=bar\
+#                             XYZ=123\
+#                             %%{nil}
+#
 # Adding device specific files to initrd folder:
 #
 # Create a folder named initrd-%{device} and copy the overriding files there.
@@ -162,8 +169,8 @@ fi
 %if 0%{!?lvm_root_size:1}
 %define lvm_root_size 2500
 %endif
-
-sed --in-place 's|@LVM_ROOT_PART_SIZE@|%{lvm_root_size}|' %{_local_initrd_dir}/etc/sysconfig/init
+INIT_FILE=%{_local_initrd_dir}/etc/sysconfig/init
+sed --in-place 's|@LVM_ROOT_PART_SIZE@|%{lvm_root_size}|' $INIT_FILE
 
 sed --in-place 's|@PHYSDEV_PART_LABEL@|%{root_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
 sed --in-place 's|@FIMAGE_PART_LABEL@|%{factory_part_label}|' %{_local_initrd_dir}/etc/sysconfig/partitions
@@ -193,6 +200,13 @@ sed --in-place 's|@BATTERY_CAPACITY_FILE@|%{battery_capacity_file}|' %{_local_in
 sed --in-place 's|@BATTERY_CAPACITY_THRESHOLD@|%{battery_capacity_threshold}|' %{_local_initrd_dir}/etc/sysconfig/recovery
 
 sed --in-place 's|@LIB_DIR@|%{_libdir}|' %{_local_initrd_dir}/usr/bin/recovery-menu-devicelock
+
+# Add device-specific environment variables from droid-hal-$DEVICE-img-boot.spec to /etc/sysconfig/init
+%if 0%{?initrd_env_vars:1}
+cat <<EOF >> $INIT_FILE
+%{?initrd_env_vars}
+EOF
+%endif
 
 # Create a hybris-boot.img image from the zImage
 %if 0%{?_obs_build_project:1}

--- a/recovery-init
+++ b/recovery-init
@@ -5,6 +5,7 @@
 # This file is part of Jolla recovery console
 #
 # Copyright (C) 2013-2015 Jolla Ltd.
+# Copyright (c) 2021 Open Mobile Platform LLC.
 # Originally written by Andrea Bernabei
 # Contact: Igor Zhbanov <igor.zhbanov@jolla.com>
 #
@@ -97,6 +98,7 @@ usb_info() {
 }
 
 set -o allexport
+. /etc/sysconfig/init
 . /etc/sysconfig/display
 . /usr/bin/recovery-functions.sh
 set +o allexport

--- a/sbin/root-mount
+++ b/sbin/root-mount
@@ -3,6 +3,7 @@
 # Jolla btrfs root mounting script, adapted for ext4
 #
 # Copyright (C) 2014 Jolla Ltd.
+# Copyright (c) 2021 Open Mobile Platform LLC.
 # Contact: Kalle Jokiniemi <kalle.jokiniemi@jolla.com>
 #
 # This program is free software; you can redistribute it and/or
@@ -32,9 +33,11 @@ if [ -z $1 ] || [ ! -e $1 ]; then
 	exit 1
 fi
 
+set -o allexport
 . /etc/sysconfig/init
 . /etc/sysconfig/partitions
 . /etc/sysconfig/display
+set +o allexport
 
 PHYSDEV_SEARCHLIST="$PHYSDEV_PART_LABEL sailfishos"
 FS_RESIZED=".fs-resized"


### PR DESCRIPTION
The problem is unable to set device-specific environment variable
in both normal and recovery initrd environment
without edit droid-hal-img-boot.inc. To resolve
this issue we can use droid-hal-$DEVICE-img-boot.spec and define macro "initrd_env_vars"
for example

%define initrd_env_vars \
FOO=bar\
XYZ=123\
%{nil}

and then handle it in initrd spec to forward variables to /etc/sysconfig/init
Also we need to add /etc/sysconfig/init to allexport section of recovery-init
so that variables appeared in recovery environment.
Also we need to add allexport section to root-mount script for appear
variables in boot initrd environment.
